### PR TITLE
Add pagination to index page and prev/next links to post pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "http://yourdomain.com" # the base hostname & protocol for your site
 twitter_username: hemang_kumar
 github_username:  hemangsk
-paginate: 2
+paginate: 5
 
 gems: [jekyll-paginate, kramdown]
 # Build settings

--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,8 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "http://yourdomain.com" # the base hostname & protocol for your site
 twitter_username: hemang_kumar
 github_username:  hemangsk
+paginate: 2
 
+gems: [jekyll-paginate, kramdown]
 # Build settings
 markdown: kramdown

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -20,5 +20,18 @@ layout: default
     {{ content }}
   </div>
 
+  <footer class="postNavigation">
+  {% if page.previous.url %}
+    <a class="postPrev" href="{{page.previous.url}}">
+        &laquo; {{page.previous.title}}
+    </a>
+  {% endif %}
+  {% if page.next.url %}
+    <a class="postNext" href="{{page.next.url}}">
+        {{page.next.title}} &raquo;
+    </a>
+  {% endif %}
+  </footer>
+
 
 </article>

--- a/css/style.scss
+++ b/css/style.scss
@@ -605,6 +605,30 @@ pre {
 }
 
 /**
+ * Pagination
+ */
+ .pagination {
+     padding-top: 3.5em;
+     text-align: center;
+ }
+ .paginationLink {
+     border: 0;
+     display: inline-block;
+     padding: 5px;
+     text-decoration: none;
+     transition: color 200ms ease-out;
+
+     &:hover,
+     &:active,
+     &:focus {
+         border: 0;
+     }
+ }
+ .paginationLinkCurrent {
+     font-style: normal;
+ }
+
+/**
  * Syntax highlighting styles
  */
 .highlight {

--- a/css/style.scss
+++ b/css/style.scss
@@ -628,6 +628,30 @@ pre {
      font-style: normal;
  }
 
+.postNavigation {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+    padding-bottom: 3em;
+
+    a:only-child {
+        width: 100%;
+    }
+}
+.postPrev,
+.postNext {
+    display: inline-block;
+    width: 49%;
+    &:hover,
+    &:active,
+    &:focus {
+        border: 0;
+    }
+}
+.postNext {
+    text-align: right;
+}
+
 /**
  * Syntax highlighting styles
  */

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ layout: default
 <div class="home">
 
 
-  {% for post in site.posts%}
+  {% for post in paginator.posts%}
   <div class="post postContent">
     <div  class="postDate"><time datetime="{{ post.date | date_to_xmlschema }}" itemprop="datePublished">{{ post.date | date: "%b %-d, %Y" }}</time>
     </div>
@@ -21,8 +21,28 @@ layout: default
     </div>
   </div>
 
-
   {% endfor %}
+  {% if paginator.total_pages > 1 %}
+    <nav class="pagination">
+      {% if paginator.previous_page %}
+        <a class="paginationLink" href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">&laquo; Prev</a>
+      {% endif %}
+
+    {% for page in (1..paginator.total_pages) %}
+      {% if page == paginator.page %}
+        <em class="paginationLink paginationLinkCurrent">{{ page }}</em>
+      {% elsif page == 1 %}
+        <a class="paginationLink" href="/">{{ page }}</a>
+      {% else %}
+        <a class="paginationLink" href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}">{{ page }}</a>
+      {% endif %}
+    {% endfor %}
+
+    {% if paginator.next_page %}
+      <a class="paginationLink" href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}">Next &raquo;</a>
+    {% endif %}
+    </nav>
+  {% endif %}
   <!--<ul class="post-list">
     {% for post in site.posts %}
       <li>


### PR DESCRIPTION
This adds:

* Jekyll pagination to the index page(s)
* links to the previous and next post

(both only show up if applicable, of course)

Looks like:

#### Pagination on index

![image](https://cloud.githubusercontent.com/assets/1827373/20889818/c5abee52-bb04-11e6-87ba-58c8316cee2f.png)
![image](https://cloud.githubusercontent.com/assets/1827373/20889833/ce8510b2-bb04-11e6-9e8f-6dbd8dba8ce0.png)


#### prev/next post links

![image](https://cloud.githubusercontent.com/assets/1827373/20889855/e9b1a828-bb04-11e6-8406-fc3fa9f3f415.png)
![image](https://cloud.githubusercontent.com/assets/1827373/20889868/f380fd22-bb04-11e6-938a-c0d0c568e1cd.png)

Closes #23 