### PR TITLE
modify navbar to show separator only between entries

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,12 +7,12 @@
 </div>
 <div class="wrapper">
   <div class="trigger site-navigation">
-    <a class="page-link" href="{{site.url}}{{site.baseurl}}">HOME</a><span class="exclamationMark">/</span>
+    <a class="page-link" href="{{site.url}}{{site.baseurl}}">HOME</a>
 
     {% for sitePage in site.pages %}
     {% if sitePage.title %}
 
-    <a class="page-link" href="{{sitePage.url | prepend: site.baseurl }}">{{sitePage.title}}</a><span class="exclamationMark">/</span>
+    <span class="exclamationMark">/</span><a class="page-link" href="{{sitePage.url | prepend: site.baseurl }}">{{sitePage.title}}</a>
     {% endif %}
     {% endfor %}
   </div>


### PR DESCRIPTION
I thought it would look better if the separator in the navbar is only shown between entries and not at the end as well.
I was not sure whether it's worth opening an issue for this, so I just fixed it. If you like the change, merge it; if you don't, close this PR.