### PR TITLE
use existing css class PostTag instead of PostDay for post.tag

### DIFF
--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -12,7 +12,7 @@ layout: page
 <div class="post postContent">
   <div  class="postDate"><time datetime="{{ post.date | date_to_xmlschema }}" itemprop="datePublished">{{ post.date | date: "%b %-d, %Y" }}</time>
   </div>
-  <div class="postDay">
+  <div class="postTag">
     {{post.tag}}
   </div>
   <br>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ layout: default
   <div class="post postContent">
     <div  class="postDate"><time datetime="{{ post.date | date_to_xmlschema }}" itemprop="datePublished">{{ post.date | date: "%b %-d, %Y" }}</time>
     </div>
-    <div class="postDay">
+    <div class="postTag">
       {{post.tag}}
     </div>
     <br>


### PR DESCRIPTION
I found two instances where the post.tag div is annotated with css class "PostDay" which doesn't exist in style.scss, but class "PostTag" exists.
As I think this was a minor typo, I fixed it for both occurrences.